### PR TITLE
Implement OrderBlockDetector and adapt strategy

### DIFF
--- a/valon_ai/order_block.py
+++ b/valon_ai/order_block.py
@@ -1,12 +1,35 @@
-"""Order block detection module."""
+class OrderBlockDetector:
+    def __init__(self, candles):
+        self.candles = candles
 
-class OrderBlockFinder:
-    """Detect order blocks in price data."""
+    def detect_bullish_ob(self):
+        bullish_obs = []
+        for i in range(2, len(self.candles) - 1):
+            curr = self.candles[i]
+            next_candle = self.candles[i + 1]
+            if curr['close'] < curr['open'] and next_candle['close'] > curr['high']:
+                bullish_obs.append({
+                    "type": "bullish",
+                    "index": i,
+                    "open": curr['open'],
+                    "low": curr['low'],
+                    "high": curr['high'],
+                    "close": curr['close']
+                })
+        return bullish_obs
 
-    def __init__(self):
-        pass
-
-    def find(self, data):
-        """Return list of detected order blocks."""
-        # TODO: implement order block detection logic
-        return []
+    def detect_bearish_ob(self):
+        bearish_obs = []
+        for i in range(2, len(self.candles) - 1):
+            curr = self.candles[i]
+            next_candle = self.candles[i + 1]
+            if curr['close'] > curr['open'] and next_candle['close'] < curr['low']:
+                bearish_obs.append({
+                    "type": "bearish",
+                    "index": i,
+                    "open": curr['open'],
+                    "low": curr['low'],
+                    "high": curr['high'],
+                    "close": curr['close']
+                })
+        return bearish_obs

--- a/valon_ai/strategy.py
+++ b/valon_ai/strategy.py
@@ -1,7 +1,7 @@
 """Core trading strategy assembly."""
 
 from .smc import SMCAnalyzer
-from .order_block import OrderBlockFinder
+from .order_block import OrderBlockDetector
 from .fair_value_gap import FairValueGapFinder
 from .break_of_structure import BreakOfStructureFinder
 from .risk_management import RiskManager
@@ -14,7 +14,9 @@ class TradingStrategy:
 
     def __init__(self):
         self.smc = SMCAnalyzer()
-        self.ob = OrderBlockFinder()
+        # OrderBlockDetector expects candle data upon initialization. We pass an
+        # empty list and update the candles when analyzing the market.
+        self.ob = OrderBlockDetector([])
         self.fvg = FairValueGapFinder()
         self.bos = BreakOfStructureFinder()
         self.risk = RiskManager()
@@ -34,9 +36,12 @@ class TradingStrategy:
 
     def analyze_market(self, data):
         """Run all analyses on the market data."""
+        # Update order block detector with the latest candle data
+        self.ob.candles = data
         return {
             "smc": self.smc.analyze(data),
-            "order_blocks": self.ob.find(data),
+            "bullish_order_blocks": self.ob.detect_bullish_ob(),
+            "bearish_order_blocks": self.ob.detect_bearish_ob(),
             "fvg": self.fvg.find(data),
             "bos": self.bos.find(data),
         }


### PR DESCRIPTION
## Summary
- add concrete `OrderBlockDetector` with bullish/bearish detection methods
- update strategy to use the new detector API

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854aa509b288328a21c80a78954591e